### PR TITLE
Implement nested resolver

### DIFF
--- a/app/codegen.yml
+++ b/app/codegen.yml
@@ -4,6 +4,7 @@ generates:
     schema: schemas/schema.graphql
     config:
       useIndexSignature: true
+      defaultMapper: Partial<{T}>
       contextType: ../context#Context
     plugins:
       - typescript

--- a/app/schemas/schema.graphql
+++ b/app/schemas/schema.graphql
@@ -3,7 +3,12 @@ type Book {
   author: String
 }
 
+type Me {
+  userID: String!
+}
+
 type Query {
+  me: Me
   books: [Book!]!
 }
 

--- a/app/schemas/schema.graphql
+++ b/app/schemas/schema.graphql
@@ -1,6 +1,10 @@
+type User {
+  id: ID!
+}
 type Book {
   title: String
-  author: String
+  authors: [User!]!
+  author: User!
 }
 
 type Me {

--- a/app/schemas/schema.graphql
+++ b/app/schemas/schema.graphql
@@ -5,11 +5,11 @@ type Book {
 
 type Me {
   userID: String!
+  books: [Book!]!
 }
 
 type Query {
   me: Me
-  books: [Book!]!
 }
 
 type Mutation {

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -30,13 +30,17 @@ const schema = loadSchemaSync(join(__dirname, "../schemas/schema.graphql"), {
 const resolvers: Resolvers = {
   Query: {
     me: (_parent, _args, _context) => {
-      return _context.me;
+      return Object.assign(_context.me, { books: [] });
+    },
+  },
+  Me: {
+    books: (_parent, _args, _context) => {
+      return books;
     },
   },
   Mutation: {
     addBook: async (_parent, _args, _context) => {
-      await admin
-        .firestore()
+      await _context.database
         .collection(`users/${_context.me!.userID}/books`)
         .doc()
         .set(
@@ -95,6 +99,7 @@ const server = new ApolloServer({
   introspection: true,
   context: async (expressContext) => ({
     me: await setUserIDForMe(expressContext.req),
+    database: admin.firestore(),
   }),
   debug: process.env["APP_ENVIRONMENT"] === "DEVELOPMENT",
 });

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -59,7 +59,10 @@ const schemaWithResolvers = addResolversToSchema({ schema, resolvers });
 const setUserIDForMe = async (
   request: express.Request
 ): Promise<Context["me"]> => {
-  if (process.env["APP_FIREBASE_AUTH_TEST_USER_ID"] != null) {
+  if (
+    process.env["APP_ENVIRONMENT"] === "DEVELOPMENT" &&
+    process.env["APP_FIREBASE_AUTH_TEST_USER_ID"] != null
+  ) {
     return {
       userID: process.env["APP_FIREBASE_AUTH_TEST_USER_ID"],
     };

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -3,7 +3,7 @@ import { loadSchemaSync } from "@graphql-tools/load";
 import { GraphQLFileLoader } from "@graphql-tools/graphql-file-loader";
 import { addResolversToSchema } from "@graphql-tools/schema";
 import { join } from "path";
-import { Resolvers } from "./types/generated/graphql";
+import { Resolvers, User } from "./types/generated/graphql";
 import { Context } from "./types/context";
 
 import admin = require("firebase-admin");
@@ -29,13 +29,21 @@ const schema = loadSchemaSync(join(__dirname, "../schemas/schema.graphql"), {
 
 const resolvers: Resolvers = {
   Query: {
-    me: (_parent, _args, _context) => {
-      return Object.assign(_context.me, { books: [] });
+    me: (_parent, _args, _context, _info) => {
+      return _context.me as any;
     },
   },
   Me: {
     books: (_parent, _args, _context) => {
-      return books;
+      return [{ title: "title" }];
+    },
+  },
+  Book: {
+    authors: (_parent, _args, _context) => {
+      return [{ id: "hogehoge" }];
+    },
+    author: (_parent, _args, _context) => {
+      return { id: "fugafuga" };
     },
   },
   Mutation: {
@@ -46,13 +54,13 @@ const resolvers: Resolvers = {
         .set(
           {
             title: "Give me star",
-            author: "bannzai",
+            author: { id: "bannzai" },
           },
           { merge: true }
         );
       return {
         title: "Give me star",
-        author: "bannzai",
+        authors: [],
       };
     },
   },

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -90,10 +90,9 @@ const setUserIDForMe = async (
 const server = new ApolloServer({
   schema: schemaWithResolvers,
   introspection: true,
-  context: async (expressContext) =>
-    ({
-      me: await setUserIDForMe(expressContext.req),
-    } as Context),
+  context: async (expressContext) => ({
+    me: await setUserIDForMe(expressContext.req),
+  }),
   debug: process.env["APP_ENVIRONMENT"] === "DEVELOPMENT",
 });
 

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -29,8 +29,8 @@ const schema = loadSchemaSync(join(__dirname, "../schemas/schema.graphql"), {
 
 const resolvers: Resolvers = {
   Query: {
-    books: (_parent, _args, _context) => {
-      return books;
+    me: (_parent, _args, _context) => {
+      return _context.me;
     },
   },
   Mutation: {

--- a/app/src/types/context.d.ts
+++ b/app/src/types/context.d.ts
@@ -1,5 +1,5 @@
+import { Me } from "./me";
+
 export type Context = {
-  me?: {
-    userID: string | null;
-  } | null;
+  me: Me | null;
 };

--- a/app/src/types/context.d.ts
+++ b/app/src/types/context.d.ts
@@ -1,5 +1,7 @@
 import { Me } from "./me";
+import admin = require("firebase-admin");
 
 export type Context = {
   me: Me | null;
+  database: admin.firestore;
 };

--- a/app/src/types/generated/graphql.ts
+++ b/app/src/types/generated/graphql.ts
@@ -22,6 +22,7 @@ export type Book = {
 export type Me = {
   __typename?: 'Me';
   userID: Scalars['String'];
+  books: Array<Book>;
 };
 
 export type Mutation = {
@@ -32,7 +33,6 @@ export type Mutation = {
 export type Query = {
   __typename?: 'Query';
   me?: Maybe<Me>;
-  books: Array<Book>;
 };
 
 export type WithIndex<TObject> = TObject & Record<string, any>;
@@ -131,6 +131,7 @@ export type BookResolvers<ContextType = Context, ParentType extends ResolversPar
 
 export type MeResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Me'] = ResolversParentTypes['Me']> = ResolversObject<{
   userID?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  books?: Resolver<Array<ResolversTypes['Book']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -140,7 +141,6 @@ export type MutationResolvers<ContextType = Context, ParentType extends Resolver
 
 export type QueryResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
   me?: Resolver<Maybe<ResolversTypes['Me']>, ParentType, ContextType>;
-  books?: Resolver<Array<ResolversTypes['Book']>, ParentType, ContextType>;
 }>;
 
 export type Resolvers<ContextType = Context> = ResolversObject<{

--- a/app/src/types/generated/graphql.ts
+++ b/app/src/types/generated/graphql.ts
@@ -19,6 +19,11 @@ export type Book = {
   author?: Maybe<Scalars['String']>;
 };
 
+export type Me = {
+  __typename?: 'Me';
+  userID: Scalars['String'];
+};
+
 export type Mutation = {
   __typename?: 'Mutation';
   addBook: Book;
@@ -26,6 +31,7 @@ export type Mutation = {
 
 export type Query = {
   __typename?: 'Query';
+  me?: Maybe<Me>;
   books: Array<Book>;
 };
 
@@ -101,6 +107,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 export type ResolversTypes = ResolversObject<{
   Book: ResolverTypeWrapper<Book>;
   String: ResolverTypeWrapper<Scalars['String']>;
+  Me: ResolverTypeWrapper<Me>;
   Mutation: ResolverTypeWrapper<{}>;
   Query: ResolverTypeWrapper<{}>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
@@ -110,6 +117,7 @@ export type ResolversTypes = ResolversObject<{
 export type ResolversParentTypes = ResolversObject<{
   Book: Book;
   String: Scalars['String'];
+  Me: Me;
   Mutation: {};
   Query: {};
   Boolean: Scalars['Boolean'];
@@ -121,16 +129,23 @@ export type BookResolvers<ContextType = Context, ParentType extends ResolversPar
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type MeResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Me'] = ResolversParentTypes['Me']> = ResolversObject<{
+  userID?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type MutationResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = ResolversObject<{
   addBook?: Resolver<ResolversTypes['Book'], ParentType, ContextType>;
 }>;
 
 export type QueryResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']> = ResolversObject<{
+  me?: Resolver<Maybe<ResolversTypes['Me']>, ParentType, ContextType>;
   books?: Resolver<Array<ResolversTypes['Book']>, ParentType, ContextType>;
 }>;
 
 export type Resolvers<ContextType = Context> = ResolversObject<{
   Book?: BookResolvers<ContextType>;
+  Me?: MeResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
 }>;

--- a/app/src/types/generated/graphql.ts
+++ b/app/src/types/generated/graphql.ts
@@ -16,7 +16,8 @@ export type Scalars = {
 export type Book = {
   __typename?: 'Book';
   title?: Maybe<Scalars['String']>;
-  author?: Maybe<Scalars['String']>;
+  authors: Array<User>;
+  author: User;
 };
 
 export type Me = {
@@ -33,6 +34,11 @@ export type Mutation = {
 export type Query = {
   __typename?: 'Query';
   me?: Maybe<Me>;
+};
+
+export type User = {
+  __typename?: 'User';
+  id: Scalars['ID'];
 };
 
 export type WithIndex<TObject> = TObject & Record<string, any>;
@@ -105,27 +111,32 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 
 /** Mapping between all available schema types and the resolvers types */
 export type ResolversTypes = ResolversObject<{
-  Book: ResolverTypeWrapper<Book>;
-  String: ResolverTypeWrapper<Scalars['String']>;
-  Me: ResolverTypeWrapper<Me>;
+  Book: ResolverTypeWrapper<Partial<Book>>;
+  String: ResolverTypeWrapper<Partial<Scalars['String']>>;
+  Me: ResolverTypeWrapper<Partial<Me>>;
   Mutation: ResolverTypeWrapper<{}>;
   Query: ResolverTypeWrapper<{}>;
-  Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
+  User: ResolverTypeWrapper<Partial<User>>;
+  ID: ResolverTypeWrapper<Partial<Scalars['ID']>>;
+  Boolean: ResolverTypeWrapper<Partial<Scalars['Boolean']>>;
 }>;
 
 /** Mapping between all available schema types and the resolvers parents */
 export type ResolversParentTypes = ResolversObject<{
-  Book: Book;
-  String: Scalars['String'];
-  Me: Me;
+  Book: Partial<Book>;
+  String: Partial<Scalars['String']>;
+  Me: Partial<Me>;
   Mutation: {};
   Query: {};
-  Boolean: Scalars['Boolean'];
+  User: Partial<User>;
+  ID: Partial<Scalars['ID']>;
+  Boolean: Partial<Scalars['Boolean']>;
 }>;
 
 export type BookResolvers<ContextType = Context, ParentType extends ResolversParentTypes['Book'] = ResolversParentTypes['Book']> = ResolversObject<{
   title?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  author?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  authors?: Resolver<Array<ResolversTypes['User']>, ParentType, ContextType>;
+  author?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -143,10 +154,16 @@ export type QueryResolvers<ContextType = Context, ParentType extends ResolversPa
   me?: Resolver<Maybe<ResolversTypes['Me']>, ParentType, ContextType>;
 }>;
 
+export type UserResolvers<ContextType = Context, ParentType extends ResolversParentTypes['User'] = ResolversParentTypes['User']> = ResolversObject<{
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type Resolvers<ContextType = Context> = ResolversObject<{
   Book?: BookResolvers<ContextType>;
   Me?: MeResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
+  User?: UserResolvers<ContextType>;
 }>;
 

--- a/app/src/types/me.ts
+++ b/app/src/types/me.ts
@@ -1,0 +1,3 @@
+export interface Me {
+  userID: string;
+}


### PR DESCRIPTION
## Abstract
- ネストしたResolverを実装
- Modelのプロパティがスキーマに沿って自動生成されるので引数のないResolverを実装したい場合は工夫が必要だった
  * defaultMapper: Partial<{T}> を設定することで解決
    * ref: https://the-guild.dev/blog/better-type-safety-for-resolvers-with-graphql-codegen
    * 設定しない場合は any で返す or とりあえずプロパティを埋める必要がある
      * 後者の場合は単数のNon Optional Typeの時に積むのでこれは現実的じゃない。前者もany付けまくるのは嫌