### PR TITLE
rename suffix

### DIFF
--- a/app/functions/src/writeSpotImageURLOnResized/function.ts
+++ b/app/functions/src/writeSpotImageURLOnResized/function.ts
@@ -105,7 +105,7 @@ module.exports = functions.storage
     );
   });
 
-const thumbnailSuffix = "120x160";
+const thumbnailSuffix = "100x140";
 
 function buildStorageURL(args: {
   userID: string;


### PR DESCRIPTION
## Abstract
映画とかで使われている画像比率の3:4の比率で画像をリサイズしていたが、そうではなく一般的なポスターの比率である5:7(1:√2) に変更する