### PR TITLE
Fix syntax of Dockerfile

### DIFF
--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -9,8 +9,6 @@ RUN yarn workspace @posusume/api run build
 FROM node:14.17.6-alpine as runner
 WORKDIR /workspace
 
-RUN mkdir -p /workspace/packages/api/schemas
-RUN mkdir -p /workspace/packages/shared
 COPY --from=builder /workspace/package.json /workspace/yarn.lock /workspace/
 COPY --from=builder /workspace/packages/shared /workspace/packages/shared/
 COPY --from=builder /workspace/packages/api/package.json /workspace/packages/api/yarn.lock /workspace/packages/api/


### PR DESCRIPTION
## Abstract
COPY コマンドの destination はディレクトリの場合は `/` で終わる必要があるので修正。ついでに不要だと思うmkdirも削除
`the destination must be a directory and end with a /`